### PR TITLE
Improve calendar resizing and mind map linking

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -182,6 +182,16 @@ main {
   background: #fff;
 }
 
+.calendar-grid .day-event-layer {
+  position: relative;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.calendar-grid .day-event-layer .event {
+  pointer-events: auto;
+}
+
 .calendar-grid .time-slot {
   border-bottom: 1px solid var(--border);
   padding: 0.4rem;
@@ -232,6 +242,7 @@ main {
   gap: 0.35rem;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
   transition: box-shadow 0.2s ease;
+  z-index: 2;
 }
 
 .calendar-grid .event:hover {
@@ -282,6 +293,10 @@ main {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.6);
   cursor: ns-resize;
+}
+
+.calendar-grid .event .resize-handle.top {
+  top: 4px;
 }
 
 .calendar-grid .event .resize-handle.bottom {


### PR DESCRIPTION
## Summary
- allow calendar events to stretch across multiple hours with top and bottom resize handles
- add overlay layers so multi-hour events render correctly inside the weekly grid
- draw visible arrowed connections between mind map nodes

## Testing
- manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68d853b24d708321a0b4e77f1a64fb1d