### PR TITLE
Fix agenda event height after returning to the app

### DIFF
--- a/script.js
+++ b/script.js
@@ -379,14 +379,29 @@ async function initData() {
 
 function initTabs() {
   const links = Array.from(document.querySelectorAll('.tab-link'));
+  const activateTab = (link) => {
+    links.forEach((l) => l.classList.remove('active'));
+    document.querySelectorAll('.tab-panel').forEach((panel) => panel.classList.remove('active'));
+    link.classList.add('active');
+    document.getElementById(link.dataset.target).classList.add('active');
+
+    if (link.dataset.target === 'calendar') {
+      requestAnimationFrame(() => {
+        renderCalendar();
+        renderEventTypes();
+      });
+    }
+  };
   links.forEach((link) => {
     link.addEventListener('click', () => {
-      links.forEach((l) => l.classList.remove('active'));
-      document.querySelectorAll('.tab-panel').forEach((panel) => panel.classList.remove('active'));
-      link.classList.add('active');
-      document.getElementById(link.dataset.target).classList.add('active');
+      activateTab(link);
     });
   });
+
+  const initiallyActive = links.find((link) => link.classList.contains('active'));
+  if (initiallyActive) {
+    activateTab(initiallyActive);
+  }
 }
 
 function initStorageControls() {


### PR DESCRIPTION
## Summary
- centralize tab activation logic so panels toggle consistently
- rerender the calendar when the agenda tab becomes active to ensure event sizing is based on visible cells

## Testing
- python -m http.server 8000
- playwright script to add an event, reload, and confirm the event keeps its height

------
https://chatgpt.com/codex/tasks/task_e_68d97a2205b08321adc259b189ddf154